### PR TITLE
Fix for missing python-memcached on python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,8 @@ RUN apk --update --no-cache add \
     php7-xml \
     php7-zip \
     py-mysqldb \
+    python \
+    py2-pip \
     python3 \
     rrdtool \
     runit \
@@ -73,6 +75,8 @@ RUN apk --update --no-cache add \
     tzdata  \
     util-linux \
     whois \
+  && pip2 install --upgrade pip \
+  && pip2 install python-memcached \
   && pip3 install --upgrade pip \
   && pip3 install python-memcached \
   && sed -i -e "s/;date\.timezone.*/date\.timezone = UTC/" /etc/php7/php.ini \


### PR DESCRIPTION
This is a fix for changes introduced in commit 513ec328e4535d1f9d4f3732e9b127c360ee39fa that broke distributed polling as the [`poller-wrapper.py` script requires python2](https://github.com/librenms/librenms/blob/master/poller-wrapper.py#L1) (as well as many [others](https://github.com/librenms/librenms/search?q=env+python2&unscoped_q=env+python2))

Closes #9