### PR TITLE
use utf8 charset and collation in mariadb

### DIFF
--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - "--sql-mode="
       - "--innodb-file-per-table=1"
       - "--lower-case-table-names=0"
+      - "--character-set-server=utf8"
+      - "--collation-server=utf8_unicode_ci"
     volumes:
       - "./db:/var/lib/mysql"
     environment:


### PR DESCRIPTION
use utf8 charset and collation in mariadb in order to prevent FAIL message on /validate page