### PR TITLE
bind ipv6

### DIFF
--- a/assets/tpls/etc/nginx/nginx.conf
+++ b/assets/tpls/etc/nginx/nginx.conf
@@ -70,6 +70,7 @@ http {
 
     server {
         listen 80;
+        listen [::]:80;
 
         root /opt/librenms/html;
         index index.php;


### PR DESCRIPTION
currently only ipv4 socket is open. if container is pure ipv6, there is no way to connect:

```
root@kube-node-6:~# nsenter -t 20122 -n ip a 
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: ip6tnl0@NONE: <NOARP> mtu 1452 qdisc noop state DOWN group default qlen 1000
    link/tunnel6 :: brd ::
4: eth0@if246: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether c2:a9:a6:c7:38:59 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet6 fde4:100:0:6::5c3/64 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::c0a9:a6ff:fec7:3859/64 scope link 
       valid_lft forever preferred_lft forever
root@kube-node-6:~# nsenter -t 20122 -n netstat -lnp
Active Internet connections (only servers)
```

```
root@kube-node-6:~# nsenter -t 20122 -n netstat -lnp
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      20286/nginx: master 
udp        0      0 0.0.0.0:161             0.0.0.0:*                           20288/snmpd         
Active UNIX domain sockets (only servers)
```