### PR TITLE
Add support to run nginx in https mode

### DIFF
--- a/doc/docker/environment-variables.md
+++ b/doc/docker/environment-variables.md
@@ -11,6 +11,9 @@
 * `REAL_IP_FROM`: Trusted addresses that are known to send correct replacement addresses (default `0.0.0.0/32`)
 * `REAL_IP_HEADER`: Request header field whose value will be used to replace the client address (default `X-Forwarded-For`)
 * `LOG_IP_VAR`: Use another variable to retrieve the remote IP address for access [log_format](http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format) on Nginx. (default `remote_addr`)
+* `CERT_PATH`: Absolute path that the SSL certificate will be mounted on in the container. Enables https mode on Nginx (on port 8000). (if not present default is http)
+* `CERT_KEY_PATH`: Absolute path that the SSL certificate key will be mounted on in the container.
+* `SERVERNAME`: Server name is the name used from Nginx and needs to be same as the SSL certificates.
 
 ### (Distributed) Poller
 

--- a/rootfs/tpls/etc/nginx/nginx.conf
+++ b/rootfs/tpls/etc/nginx/nginx.conf
@@ -59,8 +59,13 @@ http {
     gzip_static on;
 
     server {
-        listen 8000;
-        listen [::]:8000;
+        @SERVERNAME_DIRECTIVE@
+        listen 8000 @SSL@;
+        listen [::]:8000 @SSL@;
+
+        @SSL_CERT_DIRECTIVE@
+        @SSL_CERT_KEY_DIRECTIVE@
+        @SSL_CIPHERS@
 
         root /opt/librenms/html;
         index index.php;


### PR DESCRIPTION
I found that this container had no support for ssl and even attempting running behind another reverse proxy the redirects from the application that were returning `http` instead of `https` - the browsers were warning for mixed content.

This MR is adding support for SSL. Nginx is still running on port 8000 but with ssl support if the `CERT_PATH, CERT_KEY_PATH` variables are present (and the certificates mounted on in the container).
