### PR TITLE
add php7-sockets to be installed to fix warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN apk --update --no-cache add \
     php7-session \
     php7-simplexml \
     php7-snmp \
+    php7-sockets \
     php7-tokenizer \
     php7-xml \
     php7-zip \


### PR DESCRIPTION
Per https://community.librenms.org/t/v1-61-release-changelog-february-2020/11145 validation of config is performed to make sure php sockets module is installed. This change adds `php7-sockets` to the package list for the Alpine Dockerfile.