### PR TITLE
fix docker-compose examples UID/GID settings

### DIFF
--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - "./rrd-journal:/data/journal"
     environment:
       - "TZ=${TZ}"
+      - "PUID=${PUID}"
+      - "PGID=${PGID}"
       - "LOG_LEVEL=LOG_INFO"
       - "WRITE_TIMEOUT=1800"
       - "WRITE_JITTER=1800"

--- a/examples/traefik/docker-compose.yml
+++ b/examples/traefik/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       - "./rrd-journal:/data/journal"
     environment:
       - "TZ=${TZ}"
+      - "PUID=${PUID}"
+      - "PGID=${PGID}"
       - "LOG_LEVEL=LOG_INFO"
       - "WRITE_TIMEOUT=1800"
       - "WRITE_JITTER=1800"


### PR DESCRIPTION
Closes #63

when you change the PUID/PGID in the `.env` file, only the librenms
containers UID/GID are changes which causes permission issues with
rrdcached. rrdcached will still be running with UID=1000 and GID=1000.
As a result of that, no graphs will be rendered.

By adding:
```
- "PUID=${PUID}"
- "PGID=${PGID}"
```

to the rrdcache service the graphs will rendered properly because
rrdcached will also run with the same UID/GID as librenms

Signed-off-by: BlackEagle <ike.devolder@gmail.com>