### PR TITLE
Fix outdated depends_on

### DIFF
--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - db
       - memcached
       - rrdcached
-      - smtp
+      - msmtpd
     volumes:
       - "./librenms:/data"
     env_file:


### PR DESCRIPTION
The smtp service was replaced with msmtpd but this was missed in the `depends_on` list of the docker-compose file.