### PR TITLE
Alpine Linux 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} crazymax/alpine-s6:3.12
+FROM --platform=${TARGETPLATFORM:-linux/amd64} crazymax/alpine-s6:3.13
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
@@ -62,7 +62,7 @@ RUN apk --update --no-cache add \
     runit \
     shadow \
     su-exec \
-    syslog-ng=3.27.1-r0 \
+    syslog-ng=3.30.1-r0 \
     ttf-dejavu \
     tzdata \
     util-linux \

--- a/rootfs/etc/syslog-ng/syslog-ng.conf
+++ b/rootfs/etc/syslog-ng/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version:3.27
+@version:3.30
 
 options {
     chain_hostnames(off);


### PR DESCRIPTION
I've upstreamed a patch to enable snmpv3 aes256 support here; https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/18112.
So now we need to upgrade to alpine 3.13 in order to use it, see https://github.com/librenms/librenms/pull/12494 for more info.

Please note it's untested