### PR TITLE
🐛 Correct rrdtool version

### DIFF
--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -174,7 +174,7 @@ if [ -n "${RRDCACHED_SERVER}" ]; then
     cat > ${LIBRENMS_PATH}/config.d/rrdcached.php <<EOL
 <?php
 \$config['rrdcached'] = "${RRDCACHED_SERVER}";
-\$config['rrdtool_version'] = "1.7.3";
+\$config['rrdtool_version'] = "1.7.2";
 EOL
 fi
 


### PR DESCRIPTION
Based on screenshoot and https://github.com/crazy-max/docker-rrdcached/blob/52738de38975e6664342827885acdd10cf9deefa/Dockerfile#L9 the version is need to be set to version 1.7.2
![rrd error](https://user-images.githubusercontent.com/43340812/107955550-35057c80-6f9e-11eb-9700-95e2628c67a9.png)
