### PR TITLE
Update syslog-ng max-connections

### DIFF
--- a/rootfs/etc/syslog-ng/syslog-ng.conf
+++ b/rootfs/etc/syslog-ng/syslog-ng.conf
@@ -18,7 +18,7 @@ source s_sys {
 };
 
 source s_net {
-    tcp(ip(0.0.0.0), port(514));
+    tcp(ip(0.0.0.0), port(514), max-connections(300));
     udp(ip(0.0.0.0), port(514));
     unix-stream("/run/syslog-ng/syslog-ng.sock");
 };


### PR DESCRIPTION
Increased to a production amount at 300 (default 10)