### PR TITLE
Add HEALTHCHECK instruction to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,7 @@ RUN apk --update --no-cache add -t build-dependencies \
     /var/cache/apk/*
 
 COPY rootfs /
+HEALTHCHECK NONE
 
 EXPOSE 8000 514 514/udp
 VOLUME [ "/data" ]


### PR DESCRIPTION
From [this issue](https://github.com/librenms/librenms/issues/12707) related to dispatcher and redis dependency. 

Using this feature, we can use it in docker-compose.yml as follows:

```
 dispatcher:
    image: librenms/librenms:latest
    container_name: librenms_dispatcher
    hostname: librenms-dispatcher
    cap_add:
      - NET_ADMIN
      - NET_RAW
    depends_on:
      - librenms
      - redis
    volumes:
      - "./librenms:/data"
    env_file:
      - "./librenms.env"
    environment:
      - "TZ=${TZ}"
      - "PUID=${PUID}"
      - "PGID=${PGID}"
      - "DB_HOST=db"
      - "DB_NAME=${MYSQL_DATABASE}"
      - "DB_USER=${MYSQL_USER}"
      - "DB_PASSWORD=${MYSQL_PASSWORD}"
      - "DB_TIMEOUT=60"
      - "DISPATCHER_NODE_ID=dispatcher1"
      - "REDIS_HOST=redis"
      - "REDIS_PORT=6379"
      - "REDIS_DB=0"
      - "SIDECAR_DISPATCHER=1"
    restart: always
    healthcheck:
      test: ["CMD", "nc", "-w", "2", "redis", "6379"]
      interval: 10s
      timeout: 10s
      retries: 2
```