### PR TITLE
Update LibreNMS to version 21.10.1 due to discovery bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG LIBRENMS_VERSION="21.10.0"
+ARG LIBRENMS_VERSION="21.10.1"
 
 FROM crazymax/yasu:latest AS yasu
 FROM crazymax/alpine-s6:3.14-2.2.0.3


### PR DESCRIPTION
This change increments the version of LibreNMS used in the docker images to 21.10.1 in order to address the discovery bug mentioned by @murrant in https://github.com/librenms/docker/pull/235