### PR TITLE
WIP: Removing references to Nagios because of confiusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you are interested, [check out](https://hub.docker.com/r/crazymax/) my other 
 * Syslog-ng support through a ["sidecar" container](doc/docker/environment-variables.md#syslog-ng)
 * Snmp-trap support through a ["sidecar" container](doc/docker/environment-variables.md#snmptrapd)
 * Built-in LibreNMS [Weathermap plugin](https://docs.librenms.org/Extensions/Weathermap/)
-* Ability to add custom Monitoring plugins (Nagios)
+* Ability to add custom Monitoring plugins
 * Ability to add custom alert templates
 * OPCache enabled to store precompiled script bytecode in shared memory
 * [s6-overlay](https://github.com/just-containers/s6-overlay/) as process supervisor
@@ -83,7 +83,7 @@ Image: librenms/librenms:latest
   * [Dispatcher service](doc/notes/dispatcher-service.md)
   * [Add a LibreNMS plugin](doc/notes/plugins.md)
   * [Syslog-ng](doc/notes/syslog-ng.md)
-  * [Additional Monitoring plugins (Nagios)](doc/notes/additional-monitoring-plugins.md)
+  * [Additional Monitoring plugins](doc/notes/additional-monitoring-plugins.md)
   * [Custom alert templates](doc/notes/alert-templates.md)
 * [Upgrade](doc/upgrade.md)
 

--- a/doc/notes/additional-monitoring-plugins.md
+++ b/doc/notes/additional-monitoring-plugins.md
@@ -1,5 +1,7 @@
-## Additional Monitoring plugins (Nagios)
+## Additional Monitoring plugins
 
-You can add a custom Monitoring (Nagios) plugin in `/data/monitoring-plugins/`.
+You can add a custom Monitoring plugin in `/data/monitoring-plugins/`.
 
 > :warning: Container has to be restarted to propagate changes
+
+Some plugins can be found in the [Monitoring Plugins](https://github.com/monitoring-plugins/monitoring-plugins#readme) repo, or in the [unofficial fork for Nagios](https://github.com/nagios-plugins/nagios-plugins#readme).


### PR DESCRIPTION
["Monitoring Plugins"](https://github.com/monitoring-plugins/monitoring-plugins#readme) is what is being used in the Alpine distro by the image currently. 

"Monitoring Plugins" used to be "Nagios Plugins", but Nagios [seems to have split with the creators of "Monitoring Plugins".](https://www.monitoring-plugins.org/doc/faq/fork.html) "Monitoring Plugins" is made to be compatible with more than Nagios. Conflict between the two mean there is currently no connection between the repos. "Monitoring Plugins" != "Nagios Plugins", but it is _almost_ the same.

Meanwhile the ["Nagios Plugins"](https://github.com/nagios-plugins/nagios-plugins#readme) repo has been further developed. Meaning the plugins we are currently using, are behind the availiable "Nagios Plugins", and thus lack features. 

I am testing some stuff to see if there is a better way to do this. Currently, with the image we are using, we are lacking features that exists only in "Nagios Plugins". Features that were released in ["Nagios Plugins Release 2.3.0"](https://github.com/nagios-plugins/nagios-plugins/releases). While "Nagios Plugins" have more features, it's not actively worked on. "Monitoring Plugins" is actually being worked on.