### PR TITLE
Add PyWinRM to pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN apk --update --no-cache add \
     musl-dev \
     python3-dev \
   && pip3 install --upgrade pip \
-  && pip3 install python-memcached mysqlclient --upgrade \
+  && pip3 install python-memcached mysqlclient pywinrm --upgrade \
   && curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \
   && apk del build-dependencies \
   && rm -rf /var/cache/apk/* /var/www/* /tmp/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,8 @@ RUN apk --update --no-cache add \
     mariadb-dev \
     musl-dev \
     python3-dev \
-  && pip3 install --upgrade pip \
+    libffi-dev \
+  && pip3 install --upgrade pip cffi \
   && pip3 install python-memcached mysqlclient pywinrm --upgrade \
   && curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \
   && apk del build-dependencies \


### PR DESCRIPTION
Added PyWinRM to pip install to support windows agentless polling in LibreNMS. 