### PR TITLE
Add openssh-client for the check_by_ssh plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apk --update --no-cache add \
     nginx \
     nmap \
     openssl \
+    openssh-client \
     perl \
     php8 \
     php8-cli \


### PR DESCRIPTION
The monitoring plugin check_by_ssh is actually not working cause it needs the openssh-client package, which is not installed.
This PR adds the package to the Dockerfile