### PR TITLE
Autostart ircbot based on environment variable

### DIFF
--- a/rootfs/etc/cont-init.d/04-svc-main.sh
+++ b/rootfs/etc/cont-init.d/04-svc-main.sh
@@ -110,3 +110,14 @@ with-contenv
 /usr/sbin/snmpd -f -c /etc/snmp/snmpd.conf
 EOL
 chmod +x /etc/services.d/snmpd/run
+
+mkdir -p /etc/services.d/ircbot
+cat >/etc/services.d/ircbot/run <<EOL
+#!/usr/bin/with-contenv sh
+if [ $(lnms config:get irc_alert) == "true" ]; then
+  s6-setuidgid 1000:992
+  /opt/librenms/irc.php
+fi
+sleep 60
+EOL
+chmod +x /etc/services.d/ircbot/run

--- a/rootfs/etc/cont-init.d/04-svc-main.sh
+++ b/rootfs/etc/cont-init.d/04-svc-main.sh
@@ -114,10 +114,9 @@ chmod +x /etc/services.d/snmpd/run
 mkdir -p /etc/services.d/ircbot
 cat >/etc/services.d/ircbot/run <<EOL
 #!/usr/bin/with-contenv sh
-if [ $(lnms config:get irc_alert) == "true" ]; then
-  s6-setuidgid 1000:992
-  /opt/librenms/irc.php
+if [ ${LIBRENMS_IRC_SERVICE:-0} == "1" ]; then
+  s6-setuidgid ${PUID}:${PGID} /opt/librenms/irc.php
 fi
-sleep 60
+sleep 10
 EOL
 chmod +x /etc/services.d/ircbot/run


### PR DESCRIPTION
This will ensure that the irc-bot is started if the enviroment-variable LIBRENMS_IRC_SERVICE is set to "1".

You still need to enable irc_alert in the config to use the ircbot for alerting.