### PR TITLE
Add 'name' top-level attribute to docker-compose.yml

### DIFF
--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.5"
+name: librenms
 
 services:
   db:

--- a/examples/rrdcached-server/docker-compose.yml
+++ b/examples/rrdcached-server/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.5"
+name: librenms
 
 services:
   db:

--- a/examples/traefik/docker-compose.yml
+++ b/examples/traefik/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.5"
+name: librenms
 
 services:
   traefik:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.5"
+name: librenms
 
 services:
   db:


### PR DESCRIPTION
This changes the running project name from "compose" to "librenms"

Fixes #325

Note: tested only with upstream docker, i.e. "docker compose" rather than legacy "docker-compose".  If that doesn't work, then it would be better to rename the directory `examples/compose` to `examples/librenms`