### PR TITLE
Update init checks to be less restrictive

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Image: librenms/librenms:latest
 * `LOG_IP_VAR`: Use another variable to retrieve the remote IP address for access [log_format](http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format) on Nginx. (default `remote_addr`)
 * `SESSION_DRIVER`: [Driver to use for session storage](https://github.com/librenms/librenms/blob/master/config/session.php) (default `file`)
 * `CACHE_DRIVER`: [Driver to use for cache and locks](https://github.com/librenms/librenms/blob/master/config/cache.php) (default `database`)
+* `IGNORE_ERRORS`: If set to `1`, startup scripts won't exit if any failure is found. (default not defined).
 
 ### Redis
 

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -115,7 +115,7 @@ fi
 
 touch /data/logs/librenms.log
 rm -rf ${LIBRENMS_PATH}/logs
-rm -f ${LIBRENMS_PATH}/config.d/*
+rm -f ${LIBRENMS_PATH}/config.d/* || true
 mkdir -p /etc/logrotate.d
 touch /etc/logrotate.d/librenms
 

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -172,7 +172,7 @@ ipmitool: /usr/sbin/ipmitool
 EOL
 
 # Config : Disable autoupdate (set in config.php so it cannot be overridden in the webui)
-cat >${LIBRENMS_PATH}/config.d/autoupdate.php <<EOL
+(cat >${LIBRENMS_PATH}/config.d/autoupdate.php <<EOL) || true
 <?php
 \$config['update'] = 0;
 EOL

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -221,7 +221,9 @@ done
 # Fix perms
 echo "Fixing perms..."
 chown librenms:librenms /data/config /data/monitoring-plugins /data/plugins /data/rrd /data/weathermap /data/alert-templates
-chown -R librenms:librenms /data/logs ${LIBRENMS_PATH}/config.d ${LIBRENMS_PATH}/bootstrap ${LIBRENMS_PATH}/logs ${LIBRENMS_PATH}/storage
+for FOLDER in /data/logs ${LIBRENMS_PATH}/config.d ${LIBRENMS_PATH}/bootstrap ${LIBRENMS_PATH}/logs ${LIBRENMS_PATH}/storage; do
+  [ -w ${FOLDER} ] && chown -R librenms:librenms ${FOLDER}
+done
 chmod ug+rw /data/logs /data/rrd ${LIBRENMS_PATH}/bootstrap/cache ${LIBRENMS_PATH}/storage ${LIBRENMS_PATH}/storage/framework/*
 
 # Check additional Monitoring plugins

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -172,10 +172,12 @@ ipmitool: /usr/sbin/ipmitool
 EOL
 
 # Config : Disable autoupdate (set in config.php so it cannot be overridden in the webui)
-(cat >${LIBRENMS_PATH}/config.d/autoupdate.php <<EOL) || true
+if [ -w ${LIBRENMS_PATH}/config.d ]; then
+  cat >${LIBRENMS_PATH}/config.d/autoupdate.php <<EOL
 <?php
 \$config['update'] = 0;
 EOL
+fi
 
 # Config : Services
 cat >${LIBRENMS_PATH}/database/seeders/config/services.yaml <<EOL
@@ -184,7 +186,7 @@ nagios_plugins: /usr/lib/monitoring-plugins
 EOL
 
 # Config : RRDCached, apply RRDCACHED_SERVER as php as it would be expected to change with the variable
-if [ -n "${RRDCACHED_SERVER}" ]; then
+if [ -n "${RRDCACHED_SERVER}" ] && [ -w ${LIBRENMS_PATH}/config.d ]; then
   cat >${LIBRENMS_PATH}/config.d/rrdcached.php <<EOL
 <?php
 \$config['rrdcached'] = "${RRDCACHED_SERVER}";

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
+if [ -z "${IGNORE_ERRORS}" ]; then
 set -e
+fi
 
 # From https://github.com/docker-library/mariadb/blob/master/docker-entrypoint.sh#L21-L41
 # usage: file_env VAR [DEFAULT]

--- a/rootfs/etc/cont-init.d/04-svc-main.sh
+++ b/rootfs/etc/cont-init.d/04-svc-main.sh
@@ -82,7 +82,7 @@ lnms migrate --force --no-ansi --no-interaction
 artisan db:seed --force --no-ansi --no-interaction
 
 echo "Clear cache"
-artisan cache:clear --no-interaction
+artisan cache:clear --no-interaction || true
 artisan config:cache --no-interaction
 
 mkdir -p /etc/services.d/nginx

--- a/rootfs/etc/cont-init.d/04-svc-main.sh
+++ b/rootfs/etc/cont-init.d/04-svc-main.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
+if [ -z "${IGNORE_ERRORS}" ]; then
 set -e
+fi
 
 # From https://github.com/docker-library/mariadb/blob/master/docker-entrypoint.sh#L21-L41
 # usage: file_env VAR [DEFAULT]
@@ -82,7 +84,7 @@ lnms migrate --force --no-ansi --no-interaction
 artisan db:seed --force --no-ansi --no-interaction
 
 echo "Clear cache"
-artisan cache:clear --no-interaction || true
+artisan cache:clear --no-interaction
 artisan config:cache --no-interaction
 
 mkdir -p /etc/services.d/nginx


### PR DESCRIPTION
As of https://github.com/librenms/docker/pull/283 restrictive check, Docker images after `22.6.0` are not working properly for us.

We are running LibreNMS in **Kubernetes**, where we have the `config.php` mounted as `ConfigMap` (read-only for the file system), and also Redis has disabled `FLUSHDB` as a safety measure.

Changes applied in here:
- Ignore errors if cannot clean `config.d` folder initially.
- Create new `config.d` files only if folder is writable.
- Update `chown` folders only if are writtable.
- Ignore if `cache:clear` fails. (Redis)