### PR TITLE
fix: fetch all Weathermap commits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ RUN apk --update --no-cache add -t build-dependencies \
   && echo "foreach (glob(\"/data/config/*.php\") as \$filename) include \$filename;" >> config.php \
   && echo "foreach (glob(\"${LIBRENMS_PATH}/config.d/*.php\") as \$filename) include \$filename;" >> config.php \
   && ( \
-    git clone --depth=1 https://github.com/librenms-plugins/Weathermap.git ./html/plugins/Weathermap \
+    git clone https://github.com/librenms-plugins/Weathermap.git ./html/plugins/Weathermap \
     && cd ./html/plugins/Weathermap \
     && git reset --hard $WEATHERMAP_PLUGIN_COMMIT \
   ) \


### PR DESCRIPTION
For weathermap plugin, 
Having a forced `git clone --depth=1` causes `docker build` failure when selecting a different (older) commit.