### PR TITLE
syslog-ng: ipv6 support

### DIFF
--- a/rootfs/etc/syslog-ng/syslog-ng.conf
+++ b/rootfs/etc/syslog-ng/syslog-ng.conf
@@ -18,8 +18,8 @@ source s_sys {
 };
 
 source s_net {
-    tcp(ip(0.0.0.0), port(514), max-connections(300));
-    udp(ip(0.0.0.0), port(514));
+    network(transport("tcp") ip("::") ip-protocol(6) port(514) max-connections(300));
+    network(transport("udp") ip("::") ip-protocol(6) port(514));
     unix-stream("/run/syslog-ng/syslog-ng.sock");
 };
 


### PR DESCRIPTION
Make syslog-ng listen on IPv4 and IPv6