### PR TITLE
Add extra SNMP Trap MIB Dirs via Env Vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Image: librenms/librenms:latest
 * `SNMP_SECURITY_LEVEL`: Sets what security level (`noauth`|`priv`) to use (default `priv`)
 * `SNMP_ENGINEID`: Defines what SNMP EngineID to use (default `1234567890`)
 * `SNMP_DISABLE_AUTHORIZATION`: Will disable the above access control checks, and revert to the previous behaviour of accepting all incoming notifications. (default `yes`)
+* `SNMP_EXTRA_MIB_DIRS`: [Additional directories where MIB files are for SNMP Traps](https://docs.librenms.org/Extensions/SNMP-Trap-Handler/#option-2) (example `/opt/librenms/mibs/veeam`)
 
 ### Database
 

--- a/rootfs/etc/cont-init.d/08-svc-snmptrapd.sh
+++ b/rootfs/etc/cont-init.d/08-svc-snmptrapd.sh
@@ -42,6 +42,6 @@ mkdir -p /etc/services.d/snmptrapd
 cat >/etc/services.d/snmptrapd/run <<EOL
 #!/usr/bin/execlineb -P
 with-contenv
-/usr/sbin/snmptrapd -f -m ALL -M /opt/librenms/mibs:/opt/librenms/mibs/cisco udp:162 tcp:162
+/usr/sbin/snmptrapd -f -m ALL -M /opt/librenms/mibs:/opt/librenms/mibs/cisco:${SNMP_EXTRA_MIB_DIRS} udp:162 tcp:162
 EOL
 chmod +x /etc/services.d/snmptrapd/run


### PR DESCRIPTION
Clean recreate of PR
Ability to add additional MIB directories for receiving & processing SNMP traps via environmental variables