### PR TITLE
remove arm/v6 arch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Image: librenms/librenms:latest
  * Manifest List: Yes
  * Supported platforms:
    - linux/amd64
-   - linux/arm/v6
    - linux/arm/v7
    - linux/arm64
    - linux/386

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -25,7 +25,6 @@ target "image-all" {
   inherits = ["image"]
   platforms = [
     "linux/amd64",
-    "linux/arm/v6",
     "linux/arm/v7",
     "linux/arm64",
     "linux/386",


### PR DESCRIPTION
follow-up https://github.com/librenms/docker/pull/359#issuecomment-1608179462

`arm/v6` is currently broken since LibreNMS 23.6.0: https://github.com/librenms/docker/actions/runs/5357193145/jobs/9718195316?pr=359#step:7:5799

```
313.4 73 packages you are using are looking for funding.
313.4 Use the `composer fund` command to find out more!
325.0 > LibreNMS\ComposerHelper::postInstall
330.4 > Illuminate\Foundation\ComposerScripts::postInstall
330.4 > @php artisan vue-i18n:generate --multi-locales --format=umd
337.1 > @php artisan view:cache
342.9 Script @php artisan view:cache handling the post-install-cmd event returned with error code 135
```

@murrant Not sure what the root cause is but it might be related to laravel deps update: https://github.com/librenms/librenms/compare/23.5.0...23.6.0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R37-R40

Suggest to just remove `arm/v6` arch support. Also recently Raspberry Pi OS [started defaulting to a 64-bit kernel on boot](https://github.com/raspberrypi/linux/issues/5402) so it seems 32-bit Arm will not be supported anymore anyway. Users should just move to `arm64` if they complain.