### PR TITLE
Fix for /opt/librenms/cache ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,7 @@ RUN apk --update --no-cache add -t build-dependencies \
     && git reset --hard $WEATHERMAP_PLUGIN_COMMIT \
   ) \
   && chown -R nobody:nogroup ${LIBRENMS_PATH} \
+  && chown -R librenms:librenms ${LIBRENMS_PATH}/cache \
   && apk del build-dependencies \
   && rm -rf .git \
     html/plugins/Test \

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,6 @@ RUN apk --update --no-cache add -t build-dependencies \
     && git reset --hard $WEATHERMAP_PLUGIN_COMMIT \
   ) \
   && chown -R nobody:nogroup ${LIBRENMS_PATH} \
-  && chown -R librenms:librenms ${LIBRENMS_PATH}/cache \
   && apk del build-dependencies \
   && rm -rf .git \
     html/plugins/Test \

--- a/rootfs/etc/cont-init.d/02-fix-perms.sh
+++ b/rootfs/etc/cont-init.d/02-fix-perms.sh
@@ -9,7 +9,8 @@ mkdir -p /data \
 chown librenms:librenms \
   /data \
   "${LIBRENMS_PATH}" \
-  "${LIBRENMS_PATH}/.env"
+  "${LIBRENMS_PATH}/.env" \
+  "${LIBRENMS_PATH}/cache"
 chown -R librenms:librenms \
   /home/librenms \
   /tpls \


### PR DESCRIPTION
closes #262 

Not a lot of wizardry here - I added a line to the Dockerfile to properly initialize the ownership of /opt/librenms/cache as librenms:librenms instead of nobody:nobody.

Thanks @undefinedid for pointing out from where the condition was arising.

I tested on my installation with no ill effects.