### PR TITLE
Update 02-fix-perms.sh for rrd folder

### DIFF
--- a/rootfs/etc/cont-init.d/02-fix-perms.sh
+++ b/rootfs/etc/cont-init.d/02-fix-perms.sh
@@ -10,7 +10,8 @@ chown librenms:librenms \
   /data \
   "${LIBRENMS_PATH}" \
   "${LIBRENMS_PATH}/.env" \
-  "${LIBRENMS_PATH}/cache"
+  "${LIBRENMS_PATH}/cache" \
+  "${LIBRENMS_PATH}/rrd"
 chown -R librenms:librenms \
   /home/librenms \
   /tpls \


### PR DESCRIPTION
Since Librenms 23.10.0 each poller needs to create a folder in /opt/librenms/rrd. 
See https://community.librenms.org/t/rrd-folders-not-getting-created/22474/26.
Without this permission the eventlog creates message "Failed to create rrd directory: /opt/librenms/rrd/x.x.x.x/" with every device poll. Harmless but a nuisance. 