### PR TITLE
Update MariaDB and Redis

### DIFF
--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -2,7 +2,7 @@ name: librenms
 
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb:10
     container_name: librenms_db
     command:
       - "mysqld"
@@ -21,7 +21,7 @@ services:
     restart: always
 
   redis:
-    image: redis:5.0-alpine
+    image: redis:7.2-alpine
     container_name: librenms_redis
     environment:
       - "TZ=${TZ}"

--- a/examples/pwd/librenms.yml
+++ b/examples/pwd/librenms.yml
@@ -25,7 +25,7 @@ x-envlibrenms: &envlibrenms
 
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb:10.11
     command:
       - "mysqld"
       - "--innodb-file-per-table=1"
@@ -43,7 +43,7 @@ services:
     restart: always
 
   redis:
-    image: redis:5.0-alpine
+    image: redis:7.2-alpine
     environment:
       TZ: *TZ
     restart: always

--- a/examples/rrdcached-server/compose.yml
+++ b/examples/rrdcached-server/compose.yml
@@ -2,7 +2,7 @@ name: librenms
 
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb:10
     container_name: librenms_db
     command:
       - "mysqld"
@@ -21,7 +21,7 @@ services:
     restart: always
 
   redis:
-    image: redis:5.0-alpine
+    image: redis:7.2-alpine
     container_name: librenms_redis
     environment:
       - "TZ=${TZ}"

--- a/examples/traefik/compose.yml
+++ b/examples/traefik/compose.yml
@@ -36,7 +36,7 @@ services:
     restart: always
 
   db:
-    image: mariadb:10.5
+    image: mariadb:10
     container_name: librenms_db
     command:
       - "mysqld"
@@ -55,7 +55,7 @@ services:
     restart: always
 
   redis:
-    image: redis:5.0-alpine
+    image: redis:7.2-alpine
     container_name: librenms_redis
     environment:
       - "TZ=${TZ}"

--- a/test/compose.yml
+++ b/test/compose.yml
@@ -2,7 +2,7 @@ name: librenms
 
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb:10
     container_name: librenms_db
     command:
       - "mysqld"
@@ -21,7 +21,7 @@ services:
     restart: always
 
   redis:
-    image: redis:5.0-alpine
+    image: redis:7.2-alpine
     container_name: librenms_redis
     environment:
       - "TZ=${TZ}"


### PR DESCRIPTION
MariaDB 10 picked because 11 renames some binaries and requires further changes (10.7->10.11)
Redis 7.2 picked as the last version with a good license