### PR TITLE
Version Error Resolve

### DIFF
--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -1,5 +1,4 @@
-name: librenms
-
+version: '3.8'  
 services:
   db:
     image: mariadb:10
@@ -155,4 +154,4 @@ services:
       - "DB_PASSWORD=${MYSQL_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "SIDECAR_SNMPTRAPD=1"
-    restart: always
+    restart: always


### PR DESCRIPTION
Version requeiRROR: The Compose file './compose.yml' is invalid because:
'name' does not match any of the regexes: '^x-'

You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the services key, or omit the version key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/ d error resolved