### PR TITLE
Saml Support in for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN apk --update --no-cache add \
     php82-sockets \
     php82-tokenizer \
     php82-xml \
+    php82-xmlwriter \
     php82-zip \
     python3 \
     py3-pip \

--- a/README.md
+++ b/README.md
@@ -195,9 +195,6 @@ Image: librenms/librenms:latest
 > in your LibreNMS container. It's particularly useful for enabling SAML authentication. 
 > The value should be a space-separated list of plugin names.
 
-
-* `DB_HOST`: MySQL database hostname / IP address
-
 ### Misc
 
 * `LIBRENMS_BASE_URL`: URL of your LibreNMS instance (default `/`)

--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ Image: librenms/librenms:latest
 * `DB_PASSWORD`: MySQL password (default `librenms`)
 * `DB_TIMEOUT`: Time in seconds after which we stop trying to reach the MySQL server (useful for clusters, default `60`)
 
+### Plugins
+* `INSTALL_PLUGINS`: Space-separated list of plugins to install
+
+> This environment variable allows you to specify which plugins should be installed
+> in your LibreNMS container. It's particularly useful for enabling SAML authentication. 
+> The value should be a space-separated list of plugin names.
+
+
+* `DB_HOST`: MySQL database hostname / IP address
+
 ### Misc
 
 * `LIBRENMS_BASE_URL`: URL of your LibreNMS instance (default `/`)

--- a/rootfs/etc/cont-init.d/09-install-plugins.sh
+++ b/rootfs/etc/cont-init.d/09-install-plugins.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/with-contenv sh
+# shellcheck shell=sh
+set -e
+
+INSTALL_PLUGINS=${INSTALL_PLUGINS:-0}
+SIDECAR_DISPATCHER=${SIDECAR_DISPATCHER:-0}
+SIDECAR_SYSLOGNG=${SIDECAR_SYSLOGNG:-0}
+SIDECAR_SNMPTRAPD=${SIDECAR_SNMPTRAPD:-0}
+
+# Exit if any sidecar is enabled
+if [ "$SIDECAR_DISPATCHER" = "1" ] || [ "$SIDECAR_SYSLOGNG" = "1" ] || [ "$SIDECAR_SNMPTRAPD" = "1" ]; then
+  exit 0
+fi
+
+# Exit if plugins are not needed
+if [ "$INSTALL_PLUGINS" = "0" ]; then
+  exit 0
+fi
+
+echo ">> Plugin configuration detected"
+
+echo "Fixing permissions..."
+chown librenms:librenms \
+  "${LIBRENMS_PATH}"/composer.* \
+  "${LIBRENMS_PATH}/logs/librenms.log" \
+  "${LIBRENMS_PATH}/scripts/composer_wrapper.php"
+
+chown -R librenms:librenms \
+  "${LIBRENMS_PATH}/scripts" \
+  "${LIBRENMS_PATH}/vendor" \
+  "${LIBRENMS_PATH}/bootstrap"
+
+# Install plugins
+lnms plugin:add "$INSTALL_PLUGINS"


### PR DESCRIPTION
I've added a new variable that allows the docker to install plugins that are needed for [SAML](https://docs.librenms.org/Extensions/OAuth-SAML/).

My access to s SAML auht service is very limited so someone need to test this further before this is fully committed.