### PR TITLE
Cron updates to support running multiple instances on a Kubernetes cluster

### DIFF
--- a/rootfs/etc/cont-init.d/04-svc-main.sh
+++ b/rootfs/etc/cont-init.d/04-svc-main.sh
@@ -33,6 +33,7 @@ DB_TIMEOUT=${DB_TIMEOUT:-60}
 SIDECAR_DISPATCHER=${SIDECAR_DISPATCHER:-0}
 SIDECAR_SYSLOGNG=${SIDECAR_SYSLOGNG:-0}
 SIDECAR_SNMPTRAPD=${SIDECAR_SNMPTRAPD:-0}
+DISABLE_DB_MIGRATE=${DISABLE_DB_MIGRATE:-0}
 
 if [ "$SIDECAR_DISPATCHER" = "1" ] || [ "$SIDECAR_SYSLOGNG" = "1" ] || [ "$SIDECAR_SNMPTRAPD" = "1" ]; then
   exit 0
@@ -77,9 +78,13 @@ if [ "${counttables}" -eq "0" ]; then
   echo "INSTALL=user,finish" >>${LIBRENMS_PATH}/.env
 fi
 
-echo "Updating database schema..."
-lnms migrate --force --no-ansi --no-interaction
-artisan db:seed --force --no-ansi --no-interaction
+if [ "${DISABLE_DB_MIGRATE}" -ne "1" ] ; then
+  echo "Updating database schema..."
+  lnms migrate --force --no-ansi --no-interaction
+  artisan db:seed --force --no-ansi --no-interaction
+else
+  echo "Skipping database migration and seeding as DISABLE_DB_MIGRATE is set to 1."
+fi
 
 echo "Clear cache"
 artisan cache:clear --no-interaction

--- a/rootfs/etc/cont-init.d/07-svc-cron.sh
+++ b/rootfs/etc/cont-init.d/07-svc-cron.sh
@@ -8,6 +8,7 @@ CRON_HOOK_PATH="/data/cron-pre-hook"
 LIBRENMS_WEATHERMAP=${LIBRENMS_WEATHERMAP:-false}
 LIBRENMS_WEATHERMAP_SCHEDULE=${LIBRENMS_WEATHERMAP_SCHEDULE:-*/5 * * * *}
 LIBRENMS_DAILY_SCHEDULE="15 0 * * *"
+LIBRENMS_SCHEDULER_SCHEDULE="* * * * *"
 
 SIDECAR_DISPATCHER=${SIDECAR_DISPATCHER:-0}
 SIDECAR_SYSLOGNG=${SIDECAR_SYSLOGNG:-0}
@@ -29,6 +30,9 @@ touch ${CRONTAB_PATH}/librenms
 # Cron
 echo "Creating LibreNMS daily.sh cron task with the following period fields: $LIBRENMS_DAILY_SCHEDULE"
 echo "${LIBRENMS_DAILY_SCHEDULE} [ -e \"${CRON_HOOK_PATH}\" ] && source \"${CRON_HOOK_PATH}\" ; cd /opt/librenms && bash daily.sh" >>${CRONTAB_PATH}/librenms
+
+echo "Creating LibreNMS scheduler cron task as we are running in a container"
+echo "${LIBRENMS_SCHEDULER_SCHEDULE} [ -e \"${CRON_HOOK_PATH}\" ] && source \"${CRON_HOOK_PATH}\" ; cd /opt/librenms && php artisan schedule:run" >>${CRONTAB_PATH}/librenms
 
 if [ "$LIBRENMS_WEATHERMAP" = "true" ] && [ -n "$LIBRENMS_WEATHERMAP_SCHEDULE" ]; then
   echo "Creating LibreNMS Weathermap cron task with the following period fields: $LIBRENMS_WEATHERMAP_SCHEDULE"


### PR DESCRIPTION
This change implements a series of features designed to support running this container in a distributed manner where multiple instances are running to support a single instance of LibreNMS, including:

* Adds the `DISABLE_DB_MIGRATE` and `DISABLE_CRON` environment variable flags that may be used to disable automatic database migration as well as running cron such that these features can be run as separate Kubernetes jobs if desired.
* Adds feature to source `/data/cron-pre-hook` into the shell environment if present prior to cronjob execution. This can be leveraged in combination with the leader-elector Kubernetes or a simple test of the index of the pod in a statefulset in order to ensure that only one container is running the cronjobs.
* Adds cronjob to run laravel's scheduled tasks as it was observed that these were not being run in containerized deployments.