### PR TITLE
Fix for Issue#276

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ RUN apk --update --no-cache add -t build-dependencies \
     && cd ./html/plugins/Weathermap \
     && git reset --hard $WEATHERMAP_PLUGIN_COMMIT \
   ) \
-  && chown -R ${PUID}:${PGID} ${LIBRENMS_PATH} \
+  && chown -R nobody:nogroup ${LIBRENMS_PATH} \
   && apk del build-dependencies \
   && rm -rf .git \
     html/plugins/Test \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN apk --update --no-cache add \
     php83-sockets \
     php83-tokenizer \
     php83-xml \
+    php83-xmlwriter \
     php83-zip \
     python3 \
     py3-pip \
@@ -135,7 +136,7 @@ RUN apk --update --no-cache add -t build-dependencies \
     && cd ./html/plugins/Weathermap \
     && git reset --hard $WEATHERMAP_PLUGIN_COMMIT \
   ) \
-  && chown -R nobody:nogroup ${LIBRENMS_PATH} \
+  && chown -R ${PUID}:${PGID} ${LIBRENMS_PATH} \
   && apk del build-dependencies \
   && rm -rf .git \
     html/plugins/Test \

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -219,7 +219,7 @@ done
 # Fix perms
 echo "Fixing perms..."
 chown librenms:librenms /data/config /data/monitoring-plugins /data/plugins /data/rrd /data/weathermap /data/alert-templates
-chown -R librenms:librenms /data/logs ${LIBRENMS_PATH}/config.d ${LIBRENMS_PATH}/bootstrap ${LIBRENMS_PATH}/logs ${LIBRENMS_PATH}/storage
+chown -R librenms:librenms /data/logs ${LIBRENMS_PATH}/composer* ${LIBRENMS_PATH}/config.d ${LIBRENMS_PATH}/bootstrap ${LIBRENMS_PATH}/logs ${LIBRENMS_PATH}/storage ${LIBRENMS_PATH}/vendor
 chmod ug+rw /data/logs /data/rrd ${LIBRENMS_PATH}/bootstrap/cache ${LIBRENMS_PATH}/storage ${LIBRENMS_PATH}/storage/framework/*
 
 # Check additional Monitoring plugins


### PR DESCRIPTION
1. Adjusted the permission fix script so that the librenms user with configurable UID/GID can change composer files and write to the vendor directory using the composer wrapper script.
2. Adding the missing extension `ext-xmlwriter`.  When debugginh the socialiteproviders auth plugin installation inside of Docker, I was able to install the plugin with `--no-platform-reqs`, which led me to believe the dependency problem is coming from the platform requirement checks.

In fact, this extension existed in our non-container installation environment where composer doesn't try to install phpunit/ext-xmlwriter(because it already pass the requirement).

**Native installation environment:**
```
# sudo -u librenms composer check-platform-reqs --lock
Checking platform requirements using the lock file
composer-plugin-api   2.2.0       success
composer-runtime-api  2.2.2       success
ext-ctype             *           success provided by symfony/polyfill-ctype
ext-curl              8.3.13      success
ext-dom               20031129    success
ext-fileinfo          8.3.13      success
ext-filter            8.3.13      success
ext-gd                8.3.13      success
ext-hash              8.3.13      success
ext-json              8.3.13      success
ext-libxml            8.3.13      success
ext-mbstring          *           success provided by symfony/polyfill-mbstring
ext-openssl           8.3.13      success
ext-pcre              8.3.13      success
ext-pdo               8.3.13      success
ext-phar              8.3.13      success
ext-session           8.3.13      success
ext-simplexml         8.3.13      success
ext-sockets           8.3.13      success
ext-tokenizer         8.3.13      success
ext-xml               8.3.13      success
ext-xmlwriter         8.3.13      success
ext-zip               1.22.3      success
ext-zlib              8.3.13      success
lib-pcre              10.42       success
php                   8.3.13      success
```

**Container/Docker installation environment:**
```
librenms:/opt/librenms# composer check-platform-reqs --lock
Checking platform requirements using the lock file
composer-plugin-api  2.6.0                                                                                            success                                       
composer-runtime-api 2.2.2                                                                                            success                                       
ext-ctype            *                                                                                                success provided by symfony/polyfill-ctype    
ext-curl             8.3.19                                                                                           success                                       
ext-dom              20031129                                                                                         success                                       
ext-fileinfo         8.3.19                                                                                           success                                       
ext-filter           8.3.19                                                                                           success                                       
ext-gd               8.3.19                                                                                           success                                       
ext-hash             8.3.19                                                                                           success                                       
ext-json             8.3.19                                                                                           success                                       
ext-libxml           8.3.19                                                                                           success                                       
ext-mbstring         *                                                                                                success provided by symfony/polyfill-mbstring 
ext-openssl          8.3.19                                                                                           success                                       
ext-pcre             8.3.19                                                                                           success                                       
ext-pdo              8.3.19                                                                                           success                                       
ext-phar             8.3.19                                                                                           success                                       
ext-session          8.3.19                                                                                           success                                       
ext-simplexml        8.3.19                                                                                           success                                       
ext-sockets          8.3.19                                                                                           success                                       
ext-tokenizer        8.3.19                                                                                           success                                       
ext-xml              8.3.19                                                                                           success                                       
ext-xmlwriter        n/a      phar-io/manifest requires ext-xmlwriter (*) phar-io/manifest requires ext-xmlwriter (*) missing                                       
ext-zip              1.22.3                                                                                           success                                       
ext-zlib             8.3.19                                                                                           success                                       
lib-pcre             10.43                                                                                            success                                       
php                  8.3.19                                                                                           success  
```

After the fix is applied, plugin installation is successfully done via lnms command.

```
librenms:/opt/librenms# lnms plugin:add socialiteproviders/microsoft
./composer.json has been updated
Running composer update socialiteproviders/microsoft
> LibreNMS\ComposerHelper::preUpdate
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking socialiteproviders/microsoft (4.6.0)
Writing lock file
Installing dependencies from lock file
Package operations: 1 install, 0 updates, 0 removals
  - Downloading socialiteproviders/microsoft (4.6.0)
  - Installing socialiteproviders/microsoft (4.6.0): Extracting archive
Package influxdb/influxdb-php is abandoned, you should avoid using it. No replacement was suggested.
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

   INFO  Discovering packages.  

  laravel-notification-channels/webpush ....................................................................................................... DONE
  laravel/socialite ........................................................................................................................... DONE
  laravel/tinker .............................................................................................................................. DONE
  laravel/ui .................................................................................................................................. DONE
  librenms/laravel-vue-i18n-generator ......................................................................................................... DONE
  mews/purifier ............................................................................................................................... DONE
  nesbot/carbon ............................................................................................................................... DONE
  nunomaduro/termwind ......................................................................................................................... DONE
  spatie/laravel-ignition ..................................................................................................................... DONE
  spatie/laravel-permission ................................................................................................................... DONE
  tightenco/ziggy ............................................................................................................................. DONE

72 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
> Illuminate\Foundation\ComposerScripts::postUpdate
No security vulnerability advisories found.
Using version ^4.6 for socialiteproviders/microsoft
The "php-http/discovery" plugin was not loaded as it is not listed in allow-plugins and is not required by the root package anymore.
Using version ^4.6 for socialiteproviders/microsoft
composer.plugins.json has been created
```

