### PR TITLE
Remove Network-WeatherMap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 
 # renovate: datasource=github-releases packageName=librenms/librenms versioning=semver
 ARG LIBRENMS_VERSION="25.6.0"
-ARG WEATHERMAP_PLUGIN_COMMIT="0b2ff643b65ee4948e4f74bb5cad5babdaddef27"
 ARG ALPINE_VERSION="3.21"
 ARG SYSLOGNG_VERSION="4.8.3-r1"
 
@@ -131,17 +130,10 @@ RUN apk --update --no-cache add -t build-dependencies \
   && sed -i '/runningUser/d' lnms \
   && echo "foreach (glob(\"/data/config/*.php\") as \$filename) include \$filename;" >> config.php \
   && echo "foreach (glob(\"${LIBRENMS_PATH}/config.d/*.php\") as \$filename) include \$filename;" >> config.php \
-  && ( \
-    git clone https://github.com/librenms-plugins/Weathermap.git ./html/plugins/Weathermap \
-    && cd ./html/plugins/Weathermap \
-    && git reset --hard $WEATHERMAP_PLUGIN_COMMIT \
-  ) \
   && chown -R nobody:nogroup ${LIBRENMS_PATH} \
   && apk del build-dependencies \
   && rm -rf .git \
     html/plugins/Test \
-    html/plugins/Weathermap/.git \
-    html/plugins/Weathermap/configs \
     doc/ \
     tests/ \
     /tmp/*

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ ___
 * [Dispatcher service](#dispatcher-service) as "sidecar" container
 * Syslog-ng support through a ["sidecar" container](#syslog-ng)
 * Snmp-trap support through a ["sidecar" container](#snmptrapd)
-* Built-in LibreNMS [Weathermap plugin](https://docs.librenms.org/Extensions/Weathermap/)
 * Ability to add custom Monitoring plugins
 * Ability to add custom alert templates
 * OPCache enabled to store precompiled script bytecode in shared memory
@@ -191,8 +190,6 @@ linux/s390x
 
 * `LIBRENMS_BASE_URL`: URL of your LibreNMS instance (default `/`)
 * `LIBRENMS_SNMP_COMMUNITY`: This container's SNMP v2c community string (default `librenmsdocker`)
-* `LIBRENMS_WEATHERMAP`: Enable LibreNMS [Weathermap plugin](https://docs.librenms.org/Extensions/Weathermap/) (default `false`)
-* `LIBRENMS_WEATHERMAP_SCHEDULE`: CRON expression format (default `*/5 * * * *`)
 * `MEMCACHED_HOST`: Hostname / IP address of a Memcached server
 * `MEMCACHED_PORT`: Port of the Memcached server (default `11211`)
 * `RRDCACHED_SERVER`: RRDcached server (eg. `rrdcached:42217`)
@@ -402,7 +399,7 @@ $ docker run -d --name librenms_snmptrapd \
 
 You can add [plugins for LibreNMS](https://docs.librenms.org/Extensions/Plugin-System/)
 in `/data/plugins/`. If you add a plugin that already exists in LibreNMS, it
-will be removed and yours will be used (except for Weathermap).
+will be removed and yours will be used.
 
 > [!WARNING]
 > Container has to be restarted to propagate changes.


### PR DESCRIPTION
As of LibreNMS version [25.3.0](https://docs.librenms.org/General/Changelog/#2530), Network-WeatherMap has been removed from the documentation as it is not supported in current PHP versions and is insecure by default.

https://github.com/librenms/librenms/pull/17239
https://docs.librenms.org/Extensions/Weathermap/

fixes #511 