### PR TITLE
Change ownership of /opt/librenms and run composer as the librenms user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,14 +124,14 @@ RUN apk --update --no-cache add -t build-dependencies \
   && echo "Installing LibreNMS https://github.com/librenms/librenms.git#${LIBRENMS_VERSION}..." \
   && git clone --depth=1 --branch ${LIBRENMS_VERSION} https://github.com/librenms/librenms.git . \
   && pip3 install --ignore-installed -r requirements.txt --upgrade --break-system-packages \
-  && COMPOSER_CACHE_DIR="/tmp" composer install --no-dev --no-interaction --no-ansi \
   && mkdir config.d \
   && cp config.php.default config.php \
   && cp snmpd.conf.example /etc/snmp/snmpd.conf \
   && sed -i '/runningUser/d' lnms \
   && echo "foreach (glob(\"/data/config/*.php\") as \$filename) include \$filename;" >> config.php \
   && echo "foreach (glob(\"${LIBRENMS_PATH}/config.d/*.php\") as \$filename) include \$filename;" >> config.php \
-  && chown -R nobody:nogroup ${LIBRENMS_PATH} \
+  && chown -R librenms:librenms ${LIBRENMS_PATH} \
+  && su librenms -s /bin/sh -c "COMPOSER_CACHE_DIR=/tmp composer install --no-dev --no-interaction --no-ansi" \
   && apk del build-dependencies \
   && rm -rf .git \
     html/plugins/Test \


### PR DESCRIPTION
This patch performs the following and allows both test workflows to succeed:
- Change ownership of /opt/librenms to the librenms user
- Run composer as the librenms user

Hopefully you find this approach acceptable.
I have only tested with a very minimal instance running under rootless Podman.