### PR TITLE
Improve startup speeds in some situations by using find before chown

### DIFF
--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -219,7 +219,7 @@ done
 # Fix perms
 echo "Fixing perms..."
 chown librenms:librenms /data/config /data/monitoring-plugins /data/plugins /data/rrd /data/weathermap /data/alert-templates
-find /data/logs ${LIBRENMS_PATH}/composer* ${LIBRENMS_PATH}/config.d ${LIBRENMS_PATH}/bootstrap ${LIBRENMS_PATH}/logs ${LIBRENMS_PATH}/storage ${LIBRENMS_PATH}/vendor  \( ! -user librenms -o ! -group librenms \) -exec chown librenms:librenms {} +
+find /data/logs ${LIBRENMS_PATH}/composer* ${LIBRENMS_PATH}/config.d ${LIBRENMS_PATH}/bootstrap ${LIBRENMS_PATH}/logs ${LIBRENMS_PATH}/storage ${LIBRENMS_PATH}/vendor \( ! -user librenms -o ! -group librenms \) -exec chown librenms:librenms {} +
 chmod ug+rw /data/logs /data/rrd ${LIBRENMS_PATH}/bootstrap/cache ${LIBRENMS_PATH}/storage ${LIBRENMS_PATH}/storage/framework/*
 
 # Check additional Monitoring plugins


### PR DESCRIPTION
Change chown lines to fix delayed startup due to long running chown (issue #524)

I can't get the command proposed by @Zugschlus in issue #524  to work when testing in a controlled environment. What does work though: 

`-not \( -user librenms -group librenms \)`

This makes it a check for files NOT owned by user librenms AND group librenms, which is what I think we are trying to achieve.

As @murrant requested, I've created a pull request with this change

fixes #524