### PR TITLE
fix: remove docker build for intel i386

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Following platforms for this image are available:
 $ docker buildx imagetools inspect librenms/librenms --format "{{json .Manifest}}" | \
   jq -r '.manifests[] | select(.platform.os != null and .platform.os != "unknown") | .platform | "\(.os)/\(.architecture)\(if .variant then "/" + .variant else "" end)"'
 
-linux/386
 linux/amd64
 linux/arm/v7
 linux/arm64

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -34,7 +34,6 @@ target "image-all" {
     "linux/amd64",
     "linux/arm/v7",
     "linux/arm64",
-    "linux/386",
     "linux/s390x"
   ]
 }


### PR DESCRIPTION
upstream of the container removed linux i386 support shortly after our last release (https://github.com/crazy-max/docker-alpine-s6/commit/c02bc702660bf7e7f8dad8f1ff0ad4ebf35360da) so the CI cannot pull the image any more. 

on hub: https://hub.docker.com/r/crazymax/alpine-s6/tags?name=3.23-2.2.0.3