### PR TITLE
feat: add automated tagging and pushing of new releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,55 @@ permissions:
 on:
   push:
     branches:
-      - 'master'
+      - "master"
     tags:
-      - '*'
+      - "*"
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
+  workflow_call:
+    inputs:
+      version:
+        description: "Upstream version without revision. When empty, tags are derived from the git ref (edge / pr-N / match)."
+        type: string
+        required: false
+        default: ""
 
 jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.compute.outputs.tags }}
+      flavor: ${{ steps.compute.outputs.flavor }}
+    steps:
+      - name: Compute metadata inputs
+        id: compute
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$VERSION" ]; then
+            {
+              echo "tags<<EOF"
+              echo "type=raw,value=${VERSION}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "flavor=latest=true" >> "$GITHUB_OUTPUT"
+          else
+            # derive tags from the git ref.
+            {
+              echo "tags<<EOF"
+              echo "type=match,pattern=(.*)-r,group=1"
+              echo "type=ref,event=pr"
+              echo "type=edge"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "flavor=latest=auto" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: meta
     uses: docker/github-builder/.github/workflows/bake.yml@v1
     permissions:
       contents: read # same as global permissions
@@ -36,10 +74,8 @@ jobs:
       set-meta-labels: true
       meta-images: |
         librenms/librenms
-      meta-tags: |
-        type=match,pattern=(.*)-r,group=1
-        type=ref,event=pr
-        type=edge
+      meta-tags: ${{ needs.meta.outputs.tags }}
+      meta-flavor: ${{ needs.meta.outputs.flavor }}
       meta-labels: |
         org.opencontainers.image.title=LibreNMS
         org.opencontainers.image.description=Fully featured network monitoring system

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: release
+
+concurrency:
+  group: release # group runs to not mess up with concurrent run due to revision incrementing
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      # upstream version is defined here
+      - "Dockerfile"
+      - "rootfs/**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # need to write the release
+    outputs:
+      released: ${{ steps.tag.outputs.released }}
+      version: ${{ steps.tag.outputs.version }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # need full tag history
+      - name: Determine version and revision
+        id: tag
+        run: |
+          set -euo pipefail
+
+          VERSION="$(sed -n 's/^ARG LIBRENMS_VERSION="\(.*\)"/\1/p' Dockerfile | head -n1)"
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read LIBRENMS_VERSION from Dockerfile" >&2
+            exit 1
+          fi
+          echo "LibreNMS version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          git fetch --tags --force
+
+          # Idempotency: if this commit is already released, do nothing.
+          EXISTING="$(git tag --points-at HEAD --list "${VERSION}-r*" | head -n1)"
+          if [ -n "$EXISTING" ]; then
+            echo "Commit already released as ${EXISTING}; skipping."
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # New version -> r0. Existing version with a new change -> next rN.
+          LAST="$(git tag --list "${VERSION}-r*" \
+            | sed -n "s/^${VERSION}-r\([0-9]\{1,\}\)$/\1/p" \
+            | sort -n | tail -n1)"
+          if [ -z "$LAST" ]; then
+            REV=0
+          else
+            REV=$((LAST + 1))
+          fi
+          TAG="${VERSION}-r${REV}"
+
+          echo "New release tag: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "released=true" >> "$GITHUB_OUTPUT"
+      - name: Create tag and release
+        if: steps.tag.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --target "$GITHUB_SHA" \
+            --generate-notes
+
+  build:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      contents: read
+      id-token: write # for signing attestations with OIDC token
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
Adding release process automation.

When master is pushed, release.yml determines the correct version to build (takes LIBRENMS_VERSION from Dockerfile), updated by renovate-bot via PR. Uses the historical commits to determine if an increase in revision (-r1) is required and falls back to "-r0" (this is a change, but technically the initial release wouldn't be a revision IMO.  It then uses workflow_dispatch to trigger the usual build-workflow for the new tag (since tags pushed by bot would not trigger a workflow).


