### PR TITLE
MariaDB container is used why still using MySQL naming

### DIFF
--- a/examples/compose/.env
+++ b/examples/compose/.env
@@ -2,6 +2,6 @@ TZ=Europe/Paris
 PUID=1000
 PGID=1000
 
-MYSQL_DATABASE=librenms
-MYSQL_USER=librenms
-MYSQL_PASSWORD=asupersecretpassword
+MARIADB_DATABASE=librenms
+MARIADB_USER=librenms
+MARIADB_PASSWORD=asupersecretpassword

--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -5,7 +5,7 @@ services:
     image: mariadb:10
     container_name: librenms_db
     command:
-      - "mysqld"
+      - "mariadbd"
       - "--innodb-file-per-table=1"
       - "--lower-case-table-names=0"
       - "--character-set-server=utf8mb4"

--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -15,9 +15,9 @@ services:
     environment:
       - "TZ=${TZ}"
       - "MARIADB_RANDOM_ROOT_PASSWORD=yes"
-      - "MYSQL_DATABASE=${MYSQL_DATABASE}"
-      - "MYSQL_USER=${MYSQL_USER}"
-      - "MYSQL_PASSWORD=${MYSQL_PASSWORD}"
+      - "MARIADB_DATABASE=${MARIADB_DATABASE}"
+      - "MARIADB_USER=${MARIADB_USER}"
+      - "MARIADB_PASSWORD=${MARIADB_PASSWORD}"
     restart: always
 
   redis:
@@ -58,9 +58,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
     restart: always
 
@@ -83,9 +83,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "DISPATCHER_NODE_ID=dispatcher1"
       - "SIDECAR_DISPATCHER=1"
@@ -117,9 +117,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "SIDECAR_SYSLOGNG=1"
     restart: always
@@ -150,9 +150,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "SIDECAR_SNMPTRAPD=1"
     restart: always

--- a/examples/pwd/librenms.yml
+++ b/examples/pwd/librenms.yml
@@ -1,9 +1,9 @@
 version: "3.5"
 
 x-env-global: &env-global
-  - &MYSQL_DATABASE "librenms"
-  - &MYSQL_USER "librenms"
-  - &MYSQL_PASSWORD "asupersecretpassword"
+  - &MARIADB_DATABASE "librenms"
+  - &MARIADB_USER "librenms"
+  - &MARIADB_PASSWORD "asupersecretpassword"
   - &TZ "UTC"
   - &PUID "1000"
   - &PGID "1000"
@@ -37,9 +37,9 @@ services:
     environment:
       TZ: *TZ
       MARIADB_RANDOM_ROOT_PASSWORD: "yes"
-      MYSQL_DATABASE: *MYSQL_DATABASE
-      MYSQL_USER: *MYSQL_USER
-      MYSQL_PASSWORD: *MYSQL_PASSWORD
+      MARIADB_DATABASE: *MARIADB_DATABASE
+      MARIADB_USER: *MARIADB_USER
+      MARIADB_PASSWORD: *MARIADB_PASSWORD
     restart: always
 
   redis:
@@ -67,9 +67,9 @@ services:
       PUID: *PUID
       PGID: *PGID
       DB_HOST: "db"
-      DB_NAME: *MYSQL_DATABASE
-      DB_USER: *MYSQL_USER
-      DB_PASSWORD: *MYSQL_PASSWORD
+      DB_NAME: *MARIADB_DATABASE
+      DB_USER: *MARIADB_USER
+      DB_PASSWORD: *MARIADB_PASSWORD
       DB_TIMEOUT: "60"
     restart: always
 
@@ -90,9 +90,9 @@ services:
       PUID: *PUID
       PGID: *PGID
       DB_HOST: "db"
-      DB_NAME: *MYSQL_DATABASE
-      DB_USER: *MYSQL_USER
-      DB_PASSWORD: *MYSQL_PASSWORD
+      DB_NAME: *MARIADB_DATABASE
+      DB_USER: *MARIADB_USER
+      DB_PASSWORD: *MARIADB_PASSWORD
       DB_TIMEOUT: "60"
       DISPATCHER_NODE_ID: "dispatcher1234"
       SIDECAR_DISPATCHER: "1"
@@ -115,9 +115,9 @@ services:
       PUID: *PUID
       PGID: *PGID
       DB_HOST: "db"
-      DB_NAME: *MYSQL_DATABASE
-      DB_USER: *MYSQL_USER
-      DB_PASSWORD: *MYSQL_PASSWORD
+      DB_NAME: *MARIADB_DATABASE
+      DB_USER: *MARIADB_USER
+      DB_PASSWORD: *MARIADB_PASSWORD
       DB_TIMEOUT: "60"
       DISPATCHER_NODE_ID: "dispatcher5678"
       SIDECAR_DISPATCHER: "1"
@@ -140,9 +140,9 @@ services:
       PUID: *PUID
       PGID: *PGID
       DB_HOST: "db"
-      DB_NAME: *MYSQL_DATABASE
-      DB_USER: *MYSQL_USER
-      DB_PASSWORD: *MYSQL_PASSWORD
+      DB_NAME: *MARIADB_DATABASE
+      DB_USER: *MARIADB_USER
+      DB_PASSWORD: *MARIADB_PASSWORD
       DB_TIMEOUT: "60"
       SIDECAR_SYSLOGNG: "1"
     restart: always

--- a/examples/pwd/librenms.yml
+++ b/examples/pwd/librenms.yml
@@ -27,7 +27,7 @@ services:
   db:
     image: mariadb:10.11
     command:
-      - "mysqld"
+      - "mariadbd"
       - "--innodb-file-per-table=1"
       - "--lower-case-table-names=0"
       - "--character-set-server=utf8mb4"

--- a/examples/rrdcached-server/.env
+++ b/examples/rrdcached-server/.env
@@ -2,6 +2,6 @@ TZ=Europe/Paris
 PUID=1000
 PGID=1000
 
-MYSQL_DATABASE=librenms
-MYSQL_USER=librenms
-MYSQL_PASSWORD=asupersecretpassword
+MARIADB_DATABASE=librenms
+MARIADB_USER=librenms
+MARIADB_PASSWORD=asupersecretpassword

--- a/examples/rrdcached-server/compose.yml
+++ b/examples/rrdcached-server/compose.yml
@@ -5,7 +5,7 @@ services:
     image: mariadb:10
     container_name: librenms_db
     command:
-      - "mysqld"
+      - "mariadbd"
       - "--innodb-file-per-table=1"
       - "--lower-case-table-names=0"
       - "--character-set-server=utf8mb4"

--- a/examples/rrdcached-server/compose.yml
+++ b/examples/rrdcached-server/compose.yml
@@ -15,9 +15,9 @@ services:
     environment:
       - "TZ=${TZ}"
       - "MARIADB_RANDOM_ROOT_PASSWORD=yes"
-      - "MYSQL_DATABASE=${MYSQL_DATABASE}"
-      - "MYSQL_USER=${MYSQL_USER}"
-      - "MYSQL_PASSWORD=${MYSQL_PASSWORD}"
+      - "MARIADB_DATABASE=${MARIADB_DATABASE}"
+      - "MARIADB_USER=${MARIADB_USER}"
+      - "MARIADB_PASSWORD=${MARIADB_PASSWORD}"
     restart: always
 
   redis:
@@ -76,9 +76,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
     restart: always
 
@@ -101,9 +101,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "DISPATCHER_NODE_ID=dispatcher1"
       - "SIDECAR_DISPATCHER=1"
@@ -135,9 +135,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "SIDECAR_SYSLOGNG=1"
     restart: always
@@ -168,9 +168,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "SIDECAR_SNMPTRAPD=1"
     restart: always

--- a/examples/traefik/.env
+++ b/examples/traefik/.env
@@ -2,6 +2,6 @@ TZ=Europe/Paris
 PUID=1000
 PGID=1000
 
-MYSQL_DATABASE=librenms
-MYSQL_USER=librenms
-MYSQL_PASSWORD=asupersecretpassword
+MARIADB_DATABASE=librenms
+MARIADB_USER=librenms
+MARIADB_PASSWORD=asupersecretpassword

--- a/examples/traefik/compose.yml
+++ b/examples/traefik/compose.yml
@@ -49,9 +49,9 @@ services:
     environment:
       - "TZ=${TZ}"
       - "MARIADB_RANDOM_ROOT_PASSWORD=yes"
-      - "MYSQL_DATABASE=${MYSQL_DATABASE}"
-      - "MYSQL_USER=${MYSQL_USER}"
-      - "MYSQL_PASSWORD=${MYSQL_PASSWORD}"
+      - "MARIADB_DATABASE=${MARIADB_DATABASE}"
+      - "MARIADB_USER=${MARIADB_USER}"
+      - "MARIADB_PASSWORD=${MARIADB_PASSWORD}"
     restart: always
 
   redis:
@@ -93,9 +93,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
     restart: always
 
@@ -115,9 +115,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "DISPATCHER_NODE_ID=dispatcher1"
       - "SIDECAR_DISPATCHER=1"
@@ -146,9 +146,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "SIDECAR_SYSLOGNG=1"
     restart: always
@@ -176,9 +176,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "SIDECAR_SNMPTRAPD=1"
     restart: always

--- a/examples/traefik/compose.yml
+++ b/examples/traefik/compose.yml
@@ -39,7 +39,7 @@ services:
     image: mariadb:10
     container_name: librenms_db
     command:
-      - "mysqld"
+      - "mariadbd"
       - "--innodb-file-per-table=1"
       - "--lower-case-table-names=0"
       - "--character-set-server=utf8mb4"

--- a/test/.env
+++ b/test/.env
@@ -2,6 +2,6 @@ TZ=Europe/Paris
 PUID=1000
 PGID=1000
 
-MYSQL_DATABASE=librenms
-MYSQL_USER=librenms
-MYSQL_PASSWORD=asupersecretpassword
+MARIADB_DATABASE=librenms
+MARIADB_USER=librenms
+MARIADB_PASSWORD=asupersecretpassword

--- a/test/compose.yml
+++ b/test/compose.yml
@@ -5,7 +5,7 @@ services:
     image: mariadb:10
     container_name: librenms_db
     command:
-      - "mysqld"
+      - "mariadbd"
       - "--innodb-file-per-table=1"
       - "--lower-case-table-names=0"
       - "--character-set-server=utf8mb4"

--- a/test/compose.yml
+++ b/test/compose.yml
@@ -15,9 +15,9 @@ services:
     environment:
       - "TZ=${TZ}"
       - "MARIADB_RANDOM_ROOT_PASSWORD=yes"
-      - "MYSQL_DATABASE=${MYSQL_DATABASE}"
-      - "MYSQL_USER=${MYSQL_USER}"
-      - "MYSQL_PASSWORD=${MYSQL_PASSWORD}"
+      - "MARIADB_DATABASE=${MARIADB_DATABASE}"
+      - "MARIADB_USER=${MARIADB_USER}"
+      - "MARIADB_PASSWORD=${MARIADB_PASSWORD}"
     restart: always
 
   redis:
@@ -50,9 +50,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
     restart: always
 
@@ -75,9 +75,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "DISPATCHER_NODE_ID=dispatcher1"
       - "SIDECAR_DISPATCHER=1"
@@ -109,9 +109,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "SIDECAR_SYSLOGNG=1"
     restart: always
@@ -142,9 +142,9 @@ services:
       - "PUID=${PUID}"
       - "PGID=${PGID}"
       - "DB_HOST=db"
-      - "DB_NAME=${MYSQL_DATABASE}"
-      - "DB_USER=${MYSQL_USER}"
-      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "DB_NAME=${MARIADB_DATABASE}"
+      - "DB_USER=${MARIADB_USER}"
+      - "DB_PASSWORD=${MARIADB_PASSWORD}"
       - "DB_TIMEOUT=60"
       - "SIDECAR_SNMPTRAPD=1"
     restart: always


### PR DESCRIPTION
MariaDB containers support for now both naming but those are now different project and they have diverged in many aspects. It is possible that those ENV variable will not be supported in the future (probably distant though).

Also, when searching for container images documentation, it helps user to get to https://hub.docker.com/_/mariadb/ instead of https://hub.docker.com/_/mysql/ where there might be differences between how env variables are used or even available to configure the DB.