### PR TITLE
Fix: prevent workflows from running on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'librenms/docker'
     uses: docker/github-builder/.github/workflows/bake.yml@v1
     permissions:
       contents: read # same as global permissions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ env:
 
 jobs:
   test:
+    if: github.repository == 'librenms/docker'
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.version == 'master' }}
     strategy:


### PR DESCRIPTION
**Description:**

This PR restricts the `build` and `test` workflows to only run on the upstream repository (`librenms/docker`).

**Changes:**
- Added `if: github.repository == 'librenms/docker'` condition to both workflow jobs

**Why:**
Forks were triggering build/test jobs unnecessarily, consuming CI resources. These workflows should only run on the upstream repo where the Docker images are actually published to Docker Hub.