### PR TITLE
Add healthcheck using native lnms health:check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,4 +145,7 @@ COPY rootfs /
 EXPOSE 8000 514 514/udp 162 162/udp
 VOLUME [ "/data" ]
 
+HEALTHCHECK --start-period=1m \
+  CMD lnms health:check || exit 1
+
 ENTRYPOINT [ "/init" ]

--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -93,6 +93,8 @@ services:
 
   syslogng:
     image: librenms/librenms:latest
+    healthcheck:
+      disable: true
     container_name: librenms_syslogng
     hostname: librenms-syslogng
     cap_add:
@@ -126,6 +128,8 @@ services:
 
   snmptrapd:
     image: librenms/librenms:latest
+    healthcheck:
+      disable: true
     container_name: librenms_snmptrapd
     hostname: librenms-snmptrapd
     cap_add:

--- a/examples/traefik/compose.yml
+++ b/examples/traefik/compose.yml
@@ -138,6 +138,8 @@ services:
 
   syslogng:
     image: librenms/librenms:latest
+    healthcheck:
+      disable: true
     container_name: librenms_syslog
     hostname: librenms-syslogng
     depends_on:
@@ -170,6 +172,8 @@ services:
 
   snmptrapd:
     image: librenms/librenms:latest
+    healthcheck:
+      disable: true
     container_name: librenms_snmptrapd
     hostname: librenms-snmptrapd
     depends_on:

--- a/test/compose.yml
+++ b/test/compose.yml
@@ -85,6 +85,8 @@ services:
 
   syslogng:
     image: ${LIBRENMS_IMAGE:-librenms/librenms:latest}
+    healthcheck:
+      disable: true
     container_name: librenms_syslogng
     hostname: librenms-syslogng
     cap_add:
@@ -118,6 +120,8 @@ services:
 
   snmptrapd:
     image: ${LIBRENMS_IMAGE:-librenms/librenms:latest}
+    healthcheck:
+      disable: true
     container_name: librenms_snmptrapd
     hostname: librenms-snmptrapd
     cap_add:


### PR DESCRIPTION
Add HEALTHCHECK instruction to Dockerfile using the native lnms health:check command with a 1m start period to allow container initialization.

Closes https://github.com/librenms/docker/pull/206